### PR TITLE
Add toString to Move class

### DIFF
--- a/src/entity/Move.java
+++ b/src/entity/Move.java
@@ -80,4 +80,16 @@ public class Move {
     public ArrayList<Integer> getDestination() {
         return destination;
     }
+
+    @Override
+    public String toString() {
+        return algebraicNotation();
+    }
+
+    public String algebraicNotation() {
+        String startingSquare = (char)(96 + origin.get(0)) + origin.get(1).toString();
+        String endingSquare = (char)(96 + destination.get(0)) + destination.get(1).toString();
+
+        return startingSquare + endingSquare;
+    }
 }

--- a/src/entity/Move.java
+++ b/src/entity/Move.java
@@ -90,6 +90,12 @@ public class Move {
         String startingSquare = (char)(96 + origin.get(0)) + origin.get(1).toString();
         String endingSquare = (char)(96 + destination.get(0)) + destination.get(1).toString();
 
-        return startingSquare + endingSquare;
+        String move = startingSquare + endingSquare;
+
+        if (isPromotion) {
+            return move + "q";
+        }
+
+        return move;
     }
 }


### PR DESCRIPTION
Adding a toString method to Move class using [UCI long algebraic notation](https://en.wikipedia.org/wiki/Algebraic_notation_(chess)#Long_algebraic_notation). This should help with communicating with the Lichess API and representing moves quickly. Let me know if we might need more/different info in the toString representation or if I missed an edge case.