### PR TITLE
Fix pawn throwing exceptions when lastMove is null and getValidMoves is called.

### DIFF
--- a/src/entity/Pawn.java
+++ b/src/entity/Pawn.java
@@ -31,7 +31,7 @@ public class Pawn extends Piece {
         }
 
         // check conditions for en passant
-        if ((lastMove.getPieceMoving() instanceof Pawn) // last move was made by a pawn
+        if (lastMove != null && (lastMove.getPieceMoving() instanceof Pawn) // last move was made by a pawn
                 && ((lastMove.getOrigin().get(1) - lastMove.getDestination().get(1)) == 2) // and it moved 2 squares
                 && (lastMove.getDestination().get(1).equals(position.get(1))) // and it ended in this pawn's row
                 && (Math.abs(lastMove.getDestination().get(0) - position.get(0)) == 1)) { // and it's right next to our pawn


### PR DESCRIPTION
Added a null check in Pawn.java before checking for en passant to fix nullPointerException when checking a pawn's first move. This happened because I was testing using instances of Move instantiated with null as parameters while Board has null as the default value for lastMove.